### PR TITLE
Create a detached gpg signature for the repo

### DIFF
--- a/convert-repo-mirror.sh
+++ b/convert-repo-mirror.sh
@@ -9,8 +9,12 @@
 #   - $MIRROR_VERSION is the version number of the mirror file to create
 
 # Create the repo metadata
-yum -y install yum-utils createrepo
+yum -y install yum-utils createrepo rpm-build
 createrepo /shared/rpmroot/opt/zenoss-repo-mirror
+
+# Create the detached gpg signature.
+PASSPHRASE=$(curl -s http://artifacts.zenoss.loc/repos/.secret/passphrase)
+gpg --batch --passphrase "${PASSPHRASE}" --detach-sign --armor /shared/rpmroot/opt/zenoss-repo-mirror/repodata/repomd.xml
 
 # Package the contents of /shared/rpmroot into a yum mirror RPM ($MIRROR_FILE)
 cd /shared


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28390
Our mirrors need to include a detached signature for the mirror contents to allow verification of the packages being installed from the mirror.  We'll convert the mirror in the mkyum container because it's already setup with gpg signing support, and create the repomd.xml.asc to enable repo_gpgcheck support.

Test run @ http://platform-jenkins.zenoss.eng/job/TestBuilds/job/iso-build/17/consoleFull