### PR TITLE
ZEN-28666: bind-utils are not installed in RM 6.0 ova

### DIFF
--- a/get-update-pkgs.sh
+++ b/get-update-pkgs.sh
@@ -56,6 +56,7 @@ yumdownloader --resolve cloud-init
 yumdownloader --resolve open-vm-tools
 yumdownloader --resolve tcpdump
 yumdownloader --resolve dnsmasq
+yumdownloader --resolve bind-utils
 
 tar -czvf ../centos7-rpms.tar.gz ./*.rpm
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28666
Add the bind-utils package to the offline mirrors.