### PR TITLE
Create OS-only mirror

### DIFF
--- a/convert-repo-mirror.sh
+++ b/convert-repo-mirror.sh
@@ -10,11 +10,11 @@
 
 # Create the repo metadata
 yum -y install yum-utils createrepo rpm-build
-createrepo /shared/rpmroot/opt/zenoss-repo-mirror
+createrepo /shared/rpmroot/opt/${MIRROR_DIRNAME}
 
 # Create the detached gpg signature.
 PASSPHRASE=$(curl -s http://artifacts.zenoss.loc/repos/.secret/passphrase)
-gpg --batch --passphrase "${PASSPHRASE}" --detach-sign --armor /shared/rpmroot/opt/zenoss-repo-mirror/repodata/repomd.xml
+gpg --batch --passphrase "${PASSPHRASE}" --detach-sign --armor /shared/rpmroot/opt/${MIRROR_DIRNAME}/repodata/repomd.xml
 
 # Package the contents of /shared/rpmroot into a yum mirror RPM ($MIRROR_FILE)
 cd /shared

--- a/create_iso.py
+++ b/create_iso.py
@@ -44,8 +44,10 @@ if __name__ == '__main__':
     # Create the Serviced ISO from base_iso + yum mirror.
     # The result is saved as an ISO
     log.info('Calling docker run to create ISO')
-    check_call('docker run -e "BASE_ISO_NAME=%s.iso" -e "YUM_MIRROR=%s" -e "ISO_FILENAME=%s" --privileged=true --rm -v=%s:/mnt/build -v=%s:/mnt/output %s' % (
+    cmd = 'docker run -e "BASE_ISO_NAME=%s.iso" -e "YUM_MIRROR=%s" -e "ISO_FILENAME=%s" --privileged=true --rm -v=%s:/mnt/build -v=%s:/mnt/output %s' % (
                 args.base_iso, args.yum_mirror, args.output_name,
                 build_dir, build_dir,
-                DOCKER_BUILDER), shell=True)
+                DOCKER_BUILDER)
+    log.info('>%s' % cmd);
+    check_call(cmd, shell=True)
 

--- a/get-update-pkgs.sh
+++ b/get-update-pkgs.sh
@@ -21,6 +21,25 @@ do
 	yumdownloader --resolve $rpm
 done
 
+# Add in all of the other utilities that we want on the appliance images
+yumdownloader --resolve telnet
+yumdownloader --resolve nmap-ncat
+yumdownloader --resolve ntp
+yumdownloader --resolve zip
+yumdownloader --resolve unzip
+yumdownloader --resolve nano
+yumdownloader --resolve sysstat
+yumdownloader --resolve yum-utils
+yumdownloader --resolve wget
+yumdownloader --resolve python-chardet
+yumdownloader --resolve cloud-init
+yumdownloader --resolve open-vm-tools
+yumdownloader --resolve tcpdump
+yumdownloader --resolve dnsmasq
+yumdownloader --resolve bind-utils
+
+tar -czvf ../centos7-os-rpms.tar.gz ./*.rpm
+
 # Install the Zenoss repo so
 curl -sO http://get.zenoss.io/yum/zenoss-repo-1-1.x86_64.rpm
 sudo yum localinstall -y zenoss-repo-1-1.x86_64.rpm
@@ -41,22 +60,4 @@ yumdownloader --enablerepo=zenoss-$CC_REPO --resolve $CC_RPM --setopt=obsoletes=
 # Remove the CC package, so that we only bundling non-zenoss RPMs.
 rm -f serviced* zenoss*
 
-# Add in all of the other utilities that we want on the appliance images
-yumdownloader --resolve telnet
-yumdownloader --resolve nmap-ncat
-yumdownloader --resolve ntp
-yumdownloader --resolve zip
-yumdownloader --resolve unzip
-yumdownloader --resolve nano
-yumdownloader --resolve sysstat
-yumdownloader --resolve yum-utils
-yumdownloader --resolve wget
-yumdownloader --resolve python-chardet
-yumdownloader --resolve cloud-init
-yumdownloader --resolve open-vm-tools
-yumdownloader --resolve tcpdump
-yumdownloader --resolve dnsmasq
-yumdownloader --resolve bind-utils
-
 tar -czvf ../centos7-rpms.tar.gz ./*.rpm
-

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -40,6 +40,7 @@ export ISO_CHECKSUM=d07ab3e615c66a8b2e9a50f4852e6a77
 #
 # Consolidate all of the artifacts in a single directory
 #
+mv -f ./output-centos*/update-os* ${CONSOLIDATED_OUTPUT}
 mv -f ./output-centos*/serviced* ${CONSOLIDATED_OUTPUT}
 mv -f ./output-centos*/*.tar.gz ${CONSOLIDATED_OUTPUT}
 mv -f ./output-centos*/packer*.log ${CONSOLIDATED_OUTPUT}

--- a/os-update/builder/makeupdateiso.sh
+++ b/os-update/builder/makeupdateiso.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Builds an ISO-based update package for Zenoss appliances
+#
+# Expects:
+#   - /build the directory with the build bundle
+#     (must include /build/manifest.json)
+#   - /common the directory with shared appliance files
+#   - /update-scripts maps to this source tree's update-scripts dir
+#   - /output the directory where the resulting ISO goes
+
+ISO_ID="${CENTOS_ABBREV}_os_update"
+ISO_FILENAME="update-os-${CENTOS_ABBREV}-bld-${BUILD_NUMBER}.x86_64.iso"
+
+cd /
+
+# make working directory
+mkdir -p working
+
+# stage files needed for update. Note that we need standard and type files
+# but we don't want to include files for other target types.
+cp update-scripts/* working
+cp /build/$OS_MIRROR working
+chmod +x working/update-zenoss.sh
+
+# build ISO
+cd /working
+mkisofs -o /output/$ISO_FILENAME \
+        -V "$ISO_ID" \
+        -R -J -v -T .
+
+chmod a+rw /output/$ISO_FILENAME

--- a/os-update/create_update.py
+++ b/os-update/create_update.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+import argparse
+import logging as log
+import os
+
+from subprocess import check_call, check_output
+from urllib import urlretrieve
+from urllib2 import urlopen
+
+log.basicConfig(level=log.INFO)
+
+# Default location for output is CWD
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Config dir is the location of the ISO configuration files and builder script
+CONFIG_DIR = os.path.abspath(os.path.join(THIS_DIR, 'builder'))
+
+# Update scripts is in the same directory as this source file
+UPDATESCRIPTS_DIR = os.path.abspath(os.path.join(THIS_DIR, 'update-scripts'))
+
+# Note: the only unmodified file between what we need to have here and the
+# zenoss-deploy update iso is the Makefile, and that just for which tag to
+# use for the builder.  Rather than cloning zenoss-deploy just to parse out
+# the ISO_TAG, we'll just use 7.2-10, which should work unless something
+# changes in how we want to put this together.
+
+# ISO Builder docker image.
+ISO_TAG = "7.2-10"
+DOCKER_BUILDER = 'docker-registry-v2.zenoss.eng/iso-build:%s' % ISO_TAG
+
+# If you do not have access to docker-registry-v2.zenoss.eng:
+# 1. Build the image with "make build"
+# 2. Set the environment variable ISO_BUILD_IMAGE to 'iso-build'
+if os.environ.get("ISO_BUILD_IMAGE"):
+    DOCKER_BUILDER = os.environ.get("ISO_BUILD_IMAGE")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description= 'Make an update ISO package.')
+    parser.add_argument('--build-dir', type=str, required=True,
+                        help='where to save appliance artifacts')
+    parser.add_argument('--build-number', type=str, required=True,
+                        help='the jenkins job build number')
+    parser.add_argument('--os-mirror', type=str, required=True,
+                        help='the os mirror rpm file')
+    args = parser.parse_args()
+
+    build_dir = os.path.abspath(args.build_dir)
+
+    # Update builder image
+    if DOCKER_BUILDER.startswith('docker-registry-v2.zenoss.eng'):
+        log.info('Calling docker pull to update the builder image')
+        check_call('docker pull %s' % DOCKER_BUILDER, shell=True)
+
+    # Create ISO
+    cmd = 'docker run --privileged=true --rm'\
+        ' -e "OS_MIRROR=%s"'\
+        ' -e "BUILD_NUMBER=%s"'\
+        ' -e "CENTOS_ABBREV=%s"'\
+        ' -v=%s:/build'\
+        ' -v=%s:/config'\
+        ' -v=%s:/update-scripts'\
+        ' -v=%s:/output'\
+        ' %s /bin/bash /config/makeupdateiso.sh' % (
+            args.os_mirror,
+            args.build_number,
+            os.environ.get("CENTOS_ABBREV"),
+            build_dir,
+            CONFIG_DIR,
+            UPDATESCRIPTS_DIR,
+            build_dir,
+            DOCKER_BUILDER)
+    log.info('Calling docker run to create the update ISO package')
+    log.info('command is "%s"' % cmd)
+    check_call(cmd, shell=True)

--- a/os-update/update-scripts/update-options.py
+++ b/os-update/update-scripts/update-options.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import os
+import subprocess
+
+# Import snack (newt for Python)
+from snack import *
+
+UPDATE_OS=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'update-os.sh')
+
+HELP="Use this iso to update the operating system for the appliance."
+
+# Helper 'callback' for help screen
+def help(screen, text):
+    ButtonChoiceWindow(screen, "Help", text, help="Help on help", buttons=('OK',))
+
+def get_screen():
+    screen = SnackScreen()
+    screen.helpCallback(help)
+    screen.pushHelpLine('Press F1 for help, arrow keys to navigate, and Enter to select an option')
+    return screen
+
+def main_menu():
+    while True:
+        screen = get_screen()
+        bcw = ButtonChoiceWindow(screen, 'Upgrade Operating System',
+                        'This iso will update the operating system.\n\nContinue?',
+                        buttons=('OK', 'Cancel'),
+                        help=HELP)
+        screen.finish()
+        if bcw == 'cancel':
+            return
+
+        # They chose to continue. Update the operating system.
+        subprocess.call('bash ' + UPDATE_OS, shell=True)
+
+if __name__ == '__main__':
+    main_menu()

--- a/os-update/update-scripts/update-os.sh
+++ b/os-update/update-scripts/update-os.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LOGFILE="/tmp/upgrade-zenoss-os-$(date +'%Y-%m%d-%H%M%S').log"
+
+function green () {
+    tput setaf 2
+    echo "$@"
+    tput sgr0
+}
+
+# Sometimes the user will press keys while a task is
+# executing.  We want to clear these keystrokes before
+# prompting for input.
+function clear_input() {
+    while read -e -t 0.1; do : ; done
+}
+
+> $LOGFILE
+exec > >(tee -a $LOGFILE)
+exec 2> >(tee -a $LOGFILE >&2)
+green "Operating System upgrade log stored at $LOGFILE."
+
+function remove_os_mirror() {
+    OLD_MIRROR=$(yum list --disablerepo=\* | awk '/^zenoss-os-mirror/ { print $1}')
+    if [ ! -z "$OLD_MIRROR" ]; then
+        green "Removing the Zenoss operating system mirror repository.."
+        yum remove -y $OLD_MIRROR &> /dev/null
+        green "...operating system mirror repository removed."
+    fi
+}
+
+function replace_os_mirror() {
+    green "Installing Zenoss operating system mirror repository..."
+    # Replace old yum-mirror, if any, with new one.
+    RHEL_VERSION=$(awk '{print $4}' /etc/redhat-release)
+    YUM_MIRROR=$(ls ${DIR}/centos${RHEL_VERSION}-os-bld-*)
+    remove_os_mirror
+    yum install -y $YUM_MIRROR 2>/dev/null
+    yum clean all
+    green "...Zenoss operating system mirror repository installed..."
+}
+
+# Update the OS based on our mirror.
+function update_os() {
+    # This should update the OS and other system libraries from our base mirror.
+    yum -y --disablerepo=\* --enablerepo=zenoss-os-mirror update --skip-broken
+}
+
+replace_os_mirror
+
+update_os
+
+remove_os_mirror
+
+green "The operating system update attempt succeeded."
+green "The update log is $LOGFILE."
+echo
+clear_input
+read -n1 -r -p "Press any key to reboot..."
+reboot

--- a/os-update/update-scripts/update-zenoss.sh
+++ b/os-update/update-scripts/update-zenoss.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+# Previously this was the main entry point for upgrading
+# CC and RM at the same time.  This is now broken into two
+# steps using a python tui menu.
+export ISOMOUNT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $ISOMOUNT/build
+
+python ${ISOMOUNT}/update-options.py

--- a/vm-get-update-pkgs.json
+++ b/vm-get-update-pkgs.json
@@ -33,6 +33,12 @@
       "source": "/home/centos/centos7-rpms.tar.gz",
       "destination": "{{user `outputdir`}}/{{user `rpm_tarfile`}}",
       "direction": "download"
+    },
+    {
+      "type": "file",
+      "source": "/home/centos/centos7-os-rpms.tar.gz",
+      "destination": "{{user `outputdir`}}/{{user `rpm_os_tarfile`}}",
+      "direction": "download"
     }
   ],
   "variables": {


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29406

We want to have an appliance upgrade iso that only performs the "yum update" for the mirror, without any of the zenoss bits.