### PR TITLE
ZEN-31506: Upgrade Docker to Address (CVE-2019-5736)

### DIFF
--- a/get-update-pkgs.sh
+++ b/get-update-pkgs.sh
@@ -15,7 +15,7 @@ sudo yum -y install yum-utils
 # each of those RPMs, and their dependencies
 #
 yum makecache fast
-RPMS=`yum --quiet list updates | grep -v 'Updated Packages' | awk '{print $1}'`
+RPMS=`repoquery --pkgnarrow=updates --nevra '*'`
 for rpm in $RPMS
 do
 	yumdownloader --resolve $rpm


### PR DESCRIPTION
```
RPMS=`yum --quiet list updates | grep -v 'Updated Packages' | awk '{print $1}'`
```

previous command has some formatting issue with a `serviced-centos-iso-build` failure:
https://platform-jenkins.zenoss.eng/job/ControlCenter/job/develop/job/serviced-centos-iso-build/37/console

```
1555431639,,ui,message,    vmware-vmx: ++ yum --quiet list updates
1555431639,,ui,message,    vmware-vmx: ++ grep -v 'Updated Packages'
1555431639,,ui,message,    vmware-vmx: ++ awk '{print $1}'
1555431640,,ui,message,    vmware-vmx: + RPMS='NetworkManager.x86_64
1555431640,,ui,message,    vmware-vmx: NetworkManager-libnm.x86_64
...
...
...
1555431640,,ui,message,    vmware-vmx: python.x86_64
1555431640,,ui,message,    vmware-vmx: python-backports-ssl_match_hostname.noarch
1555431640,,ui,message,    vmware-vmx: 3.5.0.1-1.el7
1555431640,,ui,message,    vmware-vmx: python-libs.x86_64
1555431640,,ui,message,    vmware-vmx: python-setuptools.noarch
...
...
1555431748,,ui,message,    vmware-vmx: + for rpm in '$RPMS'
1555431748,,ui,message,    vmware-vmx: + yumdownloader --resolve 3.5.0.1-1.el7
1555431748,,ui,message,    vmware-vmx: Loaded plugins: fastestmirror
1555431749,,ui,message,    vmware-vmx: Loading mirror speeds from cached hostfile
1555431749,,ui,message,    vmware-vmx: * base: mirror.dal10.us.leaseweb.net
1555431749,,ui,message,    vmware-vmx: * extras: mirror.dal10.us.leaseweb.net
1555431749,,ui,message,    vmware-vmx: * updates: mirror.dal10.us.leaseweb.net
1555431749,,ui,message,    vmware-vmx: No Match for argument 3.5.0.1-1.el7
1555431749,,ui,message,    vmware-vmx: Nothing to download
1555431749,,ui,say,==> vmware-vmx: Stopping virtual machine...
```


```
[root@ip-10-111-23-232 ~]# yum --quiet list updates | grep -v 'Updated Packages' | awk '{print $1}'
GeoIP.x86_64
ModemManager-glib.x86_64
acl.x86_64
audit.x86_64
audit-libs.x86_64
audit-libs-python.x86_64
bash.x86_64
bind-libs-lite.x86_64
bind-license.noarch
binutils.x86_64
...
...
```

```
[root@ip-10-111-23-232 ~]# repoquery --pkgnarrow=updates --nevra '*'
GeoIP-0:1.5.0-13.el7.x86_64
ModemManager-glib-0:1.6.10-1.el7.x86_64
acl-0:2.2.51-14.el7.x86_64
audit-0:2.8.4-4.el7.x86_64
audit-libs-0:2.8.4-4.el7.x86_64
audit-libs-python-0:2.8.4-4.el7.x86_64
bash-0:4.2.46-31.el7.x86_64
bind-libs-lite-32:9.9.4-73.el7_6.x86_64
bind-license-32:9.9.4-73.el7_6.noarch
binutils-0:2.27-34.base.el7.x86_64
...
...
```
