### PR TITLE
CC-4233: Upgrade Docker to 18.09.6

### DIFF
--- a/jenkinsTestServicedBuildDeps.sh
+++ b/jenkinsTestServicedBuildDeps.sh
@@ -17,7 +17,7 @@ export PACKER_CACHE_DIR="${HOME}/packer_cache"
 export PACKER_LOG=1
 export PACKER_LOG_PATH="${BUILD_DIR}/packer-${SERVICED_RPM}.log"
 
-SERVICED_ARTIFACT_BASENAME=serviced-1.6.5-0.0.343.unstable-unstable-centos7.2.1511-bld-47
+SERVICED_ARTIFACT_BASENAME=serviced-1.6.5-0.0.354.unstable-unstable-centos7.2.1511-bld-49
 SERVICED_CENTOS_ISO_URL=http://artifacts.zenoss.eng/isos/serviced/${SERVICED_ARTIFACT_BASENAME}.iso
 CHECKSUM_FILEPATH=output/${SERVICED_ARTIFACT_BASENAME}.md5sum.txt
 


### PR DESCRIPTION
```
[root@ip-10-111-23-154 ~]# rpm -qlp serviced-1.6.5-0.0.354.unstable-unstable-centos7.4.1708-bld-49.rpm | grep docker
/opt/zenoss-repo-mirror/docker-ce-18.09.6-3.el7.x86_64.rpm
/opt/zenoss-repo-mirror/docker-ce-cli-18.09.6-3.el7.x86_64.rpm
[root@ip-10-111-23-154 ~]# 
```